### PR TITLE
Use spawn-fcgi with Apache HTTP Server (2.4+)

### DIFF
--- a/manual/admin/services.md
+++ b/manual/admin/services.md
@@ -119,7 +119,8 @@ Reloading services
     If [``wwsympa.fcgi``](../man/wwsympa.8.md) script was updated, it detects
     change of itself and exits.  Then WWSympa will be automatically reloaded.
 
-    Exception is the case using nginx with initscripts: If script exits,
+    Exception is the case running separate FastCGI service with initscripts:
+    If script exits,
     it have to be restared manually by executing such as:
     ```
     # service wwsympa start
@@ -129,8 +130,9 @@ Reloading services
 
     To force reloading, restart HTTP server.
 
-    Exception is the case using nginx (either with Systemd or initscripts):
-    Only WWSympa FastCGI service (``wwsympa``) may be reloaded by
+    Exception is the case running separate FastCGI service (either with
+    Systemd or initscripts):
+    Only that service (``wwsympa``) may be reloaded by
     ``service wwsympa restart`` or ``systemctl restart wwsympa``.
 
 Stopping and starting services
@@ -140,8 +142,9 @@ Stopping and starting services
 
   1. Ensure that HTTP server is stopping.
 
-     On nginx, only WWSympa FastCGI service (``wwsympa``) may be stopped
-     in many cases: nginx itself may not be stopped.
+     If you are running separate FastCGI service, only that service
+     (``wwsympa``) may be stopped
+     in many cases: HTTP server itself may not be stopped.
 
   2. Ensure that mail server is stopping.
 
@@ -183,6 +186,7 @@ Stopping and starting services
 
   4. Start HTTP server, if necessary.
 
-     On nginx, WWSympa FastCGI service (``wwsympa``) must be started
-     along with nginx itself.
+     If you are running separate FastCGI service, that service
+     (``wwsympa``) must be started
+     along with HTTP server itself.
 

--- a/manual/install/configure-http-server-apache.md
+++ b/manual/install/configure-http-server-apache.md
@@ -1,12 +1,22 @@
 ---
-title: 'Configure HTTP server: Apache HTTP Server'
+title: 'Configure HTTP server: Apache HTTP Server (compatible with earlier version)'
 prev: configure-mail-server.md
 up: configure-http-server.md
 next: configure-http-server.md#tests
 ---
 
-Configure HTTP server: Apache HTTP Server
-=========================================
+Configure HTTP server: Apache HTTP Server (compatible with earlier version)
+===========================================================================
+
+----
+Note:
+
+  * This chapter describes configuration compatible with earlier version of
+    Apache HTTP Server (prior to 2.4).  If you are using version 2.4 or later
+    of Apache HTTP Server, see recommended instruction
+    [using separate FastCGI service](configure-http-server-spawnfcgi.md).
+
+----
 
 Requirements
 ------------

--- a/manual/install/configure-http-server-nginx.md
+++ b/manual/install/configure-http-server-nginx.md
@@ -61,6 +61,20 @@ General instruction
 
          ----
 
+       * FreeBSD ports/package
+
+         Configure and activate the service (Note:
+         Replace [``$EXECCGIDIR``](../layout.md#execcgidir) and
+         [``$PIDDIR``](../layout.md#piddir) below):
+         ```
+         # sysrc spawn_fcgi_enable="YES"
+         # sysrc spawn_fcgi_app="$EXECCGIDIR/wwsympa.fcgi"
+         # sysrc spawn_fcgi_bindsocket="$PIDDIR/wwsympa.socket"
+         # sysrc spawn_fcgi_bindsocket_mode="0600 -U www"
+         # sysrc spawn_fcgi_username="sympa"
+         # sysrc spawn_fcgi_groupname"sympa"
+         ```
+
        * System V init script
 
          If your system supports system V init script, edit

--- a/manual/install/configure-http-server-nginx.md
+++ b/manual/install/configure-http-server-nginx.md
@@ -5,8 +5,8 @@ up: configure-http-server.md
 next: configure-http-server.md#tests
 ---
 
-Configure HTTP server: Separating FastCGI service for web interface
-===================================================================
+Configure HTTP server: Using separate FastCGI service
+=====================================================
 
 Requirements
 ------------
@@ -42,76 +42,75 @@ Requirements
 General instruction
 -------------------
 
+First, install WWSympa FCGI service.  And then configure HTTP server if
+necessary.
+
 ### Install WWSympa FCGI service
+
+#### Systemd
 
   1. Register WWSympa FastCGI service.
 
-       * Systemd
+     Edit [example ``wwsympa.service``](../examples/systemd/wwsympa.service)
+     as you prefer, and copy it to Systemd system directory
+     (such as ``/usr/lib/systemd/system``) as ``wwsympa.service`` file.
 
-         Edit [example ``wwsympa.service``](../examples/systemd/wwsympa.service)
-         as you prefer, and copy it to Systemd system directory
-         (such as ``/lib/systemd/system``) as ``wwsympa.service`` file.
+     ----
+     Note:
 
-         ----
-         Note:
+       * If you installed Sympa from source, you may find a file
+         ``nginx-wwsympa.service`` in ``src/etc/script`` subdirectory of
+         source tree.  Use it as ``wwsympa.service``.
 
-           * If you installed Sympa from source, you may find a file
-             ``nginx-wwsympa.service`` in ``src/etc/script`` subdirectory of
-             source tree.  Use it as ``wwsympa.service``.
-
-         ----
-
-       * FreeBSD ports/package
-
-         Configure and activate the spawn-fcgi service (Note:
-         Replace [``$EXECCGIDIR``](../layout.md#execcgidir) and
-         [``$PIDDIR``](../layout.md#piddir) below):
-         ``` bash
-         # sysrc spawn_fcgi_enable="YES"
-         # sysrc spawn_fcgi_app="$EXECCGIDIR/wwsympa.fcgi"
-         # sysrc spawn_fcgi_bindsocket="$PIDDIR/wwsympa.socket"
-         # sysrc spawn_fcgi_bindsocket_mode="0600 -U www"
-         # sysrc spawn_fcgi_username="sympa"
-         # sysrc spawn_fcgi_groupname"sympa"
-         ```
-
-       * System V init script
-
-         If your system supports system V init script, edit
-         [example init script](../examples/initscripts/wwsympa) as you prefer,
-         and copy it to system V init directory (such as ``/etc/rc.d/init.d``)
-         as the ``wwsympa`` file.
+     ----
 
   2. Start WWSympa FastCGI service.
-
-       * Systemd
-         ```bash
-         # systemctl start wwsympa.service
-         # systemctl status wwsympa.service
-         ```
-
-       * FreeBSD ports/package
-         ```bash
-         # /usr/local/etc/rc.d/spawn-fcgi start
-         ```
-
-       * initscripts
-         ```bash
-         # service wwsympa start
-         # service wwsympa status
-         ```
+     ```bash
+     # systemctl start wwsympa.service
+     # systemctl status wwsympa.service
+     ```
 
   3. Activate WWSympa FastCGI service.
+     ```bash
+     # systemctl enable wwsympa.service
+     ```
 
-       * Systemd
-         ```bash
-         # systemctl enable wwsympa.service
-         ```
+#### FreeBSD ports/package
 
-       * initscripts
-         ```bash
-         # chkconfig wwsympa on
-         ```
+  1. Configure and activate the spawn-fcgi service (Note:
+     Replace [``$EXECCGIDIR``](../layout.md#execcgidir) and
+     [``$PIDDIR``](../layout.md#piddir) below):
+     ``` bash
+     # sysrc spawn_fcgi_enable="YES"
+     # sysrc spawn_fcgi_app="$EXECCGIDIR/wwsympa.fcgi"
+     # sysrc spawn_fcgi_bindsocket="$PIDDIR/wwsympa.socket"
+     # sysrc spawn_fcgi_bindsocket_mode="0600 -U www"
+     # sysrc spawn_fcgi_username="sympa"
+     # sysrc spawn_fcgi_groupname"sympa"
+     ```
+
+  2. Start WWSympa FastCGI service.
+     ```bash
+     # /usr/local/etc/rc.d/spawn-fcgi start
+     ```
+
+#### System V init script
+
+  1. If your system supports system V init script, edit
+     [example init script](../examples/initscripts/wwsympa) as you prefer,
+     and copy it to system V init directory (such as ``/etc/rc.d/init.d``)
+     as the ``wwsympa`` file.
+
+  2. Start WWSympa FastCGI service.
+     ```bash
+     # service wwsympa start
+     # service wwsympa status
+     ```
+
+  3. Activate WWSympa FastCGI service.
+     ```bash
+     # chkconfig wwsympa on
+     ```
 
 ### Setup HTTP server
 

--- a/manual/install/configure-http-server-nginx.md
+++ b/manual/install/configure-http-server-nginx.md
@@ -63,10 +63,10 @@ General instruction
 
        * FreeBSD ports/package
 
-         Configure and activate the service (Note:
+         Configure and activate the spawn-fcgi service (Note:
          Replace [``$EXECCGIDIR``](../layout.md#execcgidir) and
          [``$PIDDIR``](../layout.md#piddir) below):
-         ```
+         ``` bash
          # sysrc spawn_fcgi_enable="YES"
          # sysrc spawn_fcgi_app="$EXECCGIDIR/wwsympa.fcgi"
          # sysrc spawn_fcgi_bindsocket="$PIDDIR/wwsympa.socket"
@@ -90,7 +90,12 @@ General instruction
          # systemctl status wwsympa.service
          ```
 
-       * initscripts or FreeBSD ports
+       * FreeBSD ports/package
+         ```bash
+         # /usr/local/etc/rc.d/spawn-fcgi start
+         ```
+
+       * initscripts
          ```bash
          # service wwsympa start
          # service wwsympa status

--- a/manual/install/configure-http-server-nginx.md
+++ b/manual/install/configure-http-server-nginx.md
@@ -19,10 +19,18 @@ Requirements
     ----
     Note:
 
-      * For Apache HTTP Server: Instruction described here needs
-        mod_proxy_fcgi module introduced by HTTP Server 2.4.
-        See [another instruction](configure-http-server-apache.md) to know
-        about configuration with HTTP Server prior to 2.4.
+      * For Apache HTTP Server:
+
+          * Instruction described here needs mod_proxy_fcgi module introduced
+            by HTTP Server 2.4.
+            See [another instruction](configure-http-server-apache.md) to know
+            about configuration with HTTP Server prior to 2.4.
+
+          * Sympa prior to 6.2.25b.1 has
+            [a bug](https://github.com/sympa-community/sympa/pull/164) and
+            doesn't work properly with the method described in this chapter.
+            Upgrading to recent version is recommended, or see
+            [another instruction](configure-http-server-apache.md).
 
     ----
 
@@ -97,7 +105,7 @@ instruction below.
      replace [``$PIDDIR``](../layout.md#piddir),
      [``$EXECCGIDIR``](../layout.md#execcgidir) and
      [``$STATICDIR``](../layout.md#staticdir) below):
-     ```
+     ``` code
      server {
          listen      80;
          server_name localhost.localdomain;  # Change it!
@@ -144,7 +152,8 @@ instruction below.
   1. Add following excerpt to httpd configuration (Note:
      replace [``$PIDDIR``](../layout.md#piddir) and
      [``$STATICDIR``](../layout.md#staticdir) below):
-     ```
+     ``` code
+     LoadModule alias_module modules/mod_alias.so
      LoadModule proxy_module modules/mod_proxy.so
      LoadModule proxy_fcgi_module modules/mod_proxy_fcgi.so
 

--- a/manual/install/configure-http-server-spawnfcgi.md
+++ b/manual/install/configure-http-server-spawnfcgi.md
@@ -1,8 +1,10 @@
 ---
-title: 'Configure HTTP server: nginx'
+title: 'Configure HTTP server: Using separate FastCGI service'
 prev: configure-mail-server.md
 up: configure-http-server.md
 next: configure-http-server.md#tests
+redirect_from:
+  - configure-http-server-nginx.html
 ---
 
 Configure HTTP server: Using separate FastCGI service

--- a/manual/install/configure-http-server-spawnfcgi.md
+++ b/manual/install/configure-http-server-spawnfcgi.md
@@ -7,8 +7,8 @@ redirect_from:
   - configure-http-server-nginx.html
 ---
 
-Configure HTTP server: Using separate FastCGI service
-=====================================================
+Configure HTTP server: Running separate FastCGI service
+=======================================================
 
 Requirements
 ------------
@@ -16,15 +16,17 @@ Requirements
   * HTTP server.
 
     Currently, [nginx](https://nginx.org/en/download.html)
-    and Apache HTTP Serever (2.4 or later) are reported working.
+    and [Apache HTTP Serever](https://httpd.apache.org/download.cgi)
+    (2.4 or later) are reported working.
 
     ----
     Note:
 
       * For Apache HTTP Server:
 
-          * Instruction described here needs mod_proxy_fcgi module introduced
-            by HTTP Server 2.4.
+          * Instruction described here needs
+            [mod_proxy_fcgi](https://httpd.apache.org/docs/mod/mod_proxy_fcgi.html)
+            module introduced by HTTP Server 2.4.
             See [another instruction](configure-http-server-apache.md) to know
             about configuration with HTTP Server prior to 2.4.
 

--- a/manual/install/configure-http-server-spawnfcgi.md
+++ b/manual/install/configure-http-server-spawnfcgi.md
@@ -84,7 +84,7 @@ necessary.
      [``$PIDDIR``](../layout.md#piddir) below):
      ``` bash
      # sysrc spawn_fcgi_enable="YES"
-     # sysrc spawn_fcgi_app="$EXECCGIDIR/wwsympa.fcgi"
+     # sysrc spawn_fcgi_app="/usr/local/bin/perl"
      # sysrc spawn_fcgi_bindsocket="$PIDDIR/wwsympa.socket"
      # sysrc spawn_fcgi_bindsocket_mode="0600 -U www"
      # sysrc spawn_fcgi_username="sympa"

--- a/manual/install/configure-http-server.md
+++ b/manual/install/configure-http-server.md
@@ -150,9 +150,11 @@ Single domain setting
 Instruction by HTTP servers
 ---------------------------
 
-  - [Apache HTTP Server](configure-http-server-apache.md)
+  - [Apache HTTP Server](configure-http-server-spawnfcgi.md) (2.4 or later)
+  - [Apache HTTP Server](configure-http-server-apache.md) (setting compatible
+    with earlier version)
+  - [nginx](configure-http-server-spawnfcgi.md)
   - [lighttpd](configure-http-server-lighttpd.md)
-  - [nginx](configure-http-server-nginx.md)
 
 Tests
 -----

--- a/manual/upgrade/in-place.md
+++ b/manual/upgrade/in-place.md
@@ -43,8 +43,8 @@ See also "[Stopping services](../admin/services.md#stopping-services)".
 
   * HTTP server should be stopped.
 
-    On nginx, WWSympa FastCGI service should be stopped at least: nginx itself
-    may not be stopped.
+    If you are running separate FastCGI service, that service should be
+    stopped at least: HTTP server itself may not be stopped.
 
   * Mail transfer agent (MTA) is recommended to be stopped.
     If it was not stopped, incoming messages will be queued into the spools of


### PR DESCRIPTION
I found that the method with WWSympa as separate FastCGI server using spawn-fcgi can be applicatble to Apache HTTP Server 2.4, along with nginx.  It looks for me more stable than the method using mod_fcgid.

I propose updating documentation and recommending this method for Apache 2.4 or later.

**Note**:

  * To use this method with Apache, [a patch to fix bug about HTTP redirect](https://github.com/sympa-community/sympa/pull/164) have to be applied (patch will be included in Sympa 6.2.25b.1).