### PR TITLE
fix example lighttpd configuration

### DIFF
--- a/manual/install/configure-http-server-lighttpd.md
+++ b/manual/install/configure-http-server-lighttpd.md
@@ -31,7 +31,7 @@ General instruction
 
      alias.url += ( "/static-sympa/" => "$STATICDIR/" )
 
-     $HTTP["url"] =~ "\^/sympa" {
+     $HTTP["url"] =~ "^/sympa" {
      fastcgi.server = ( "/sympa" =>
          ((    "check-local"    =>    "disable",
              "bin-path"    =>    "$EXECCGIDIR/wwsympa-wrapper.fcgi",


### PR DESCRIPTION
`$HTTP["url"] =~ "\^/sympa"` => `$HTTP["url"] =~ "^/sympa"`

I'm using `lighttpd/1.4.49`. This configuration wasn't working for me; it would throw a 404 when I tried to get `/sympa`. The new configuration works for me.