### PR TITLE
An update of instruction on Oracle

### DIFF
--- a/manual/install/setup-database-oracle.md
+++ b/manual/install/setup-database-oracle.md
@@ -22,27 +22,87 @@ General instruction
      values for these parameters:
      [``db_type``](../man/sympa.conf.5.md#db_type),
      [``db_name``](../man/sympa.conf.5.md#db_name),
-     [``db_host``](../man/sympa.conf.5.md#db_host),
+     [``db_host``](../man/sympa.conf.5.md#db_host) (optional),
+     [``db_port``](../man/sympa.conf.5.md#db_port) (optional),
      [``db_user``](../man/sympa.conf.5.md#db_user),
      [``db_passwd``](../man/sympa.conf.5.md#db_passwd) and
      [``db_env``](../man/sympa.conf.5.md#db_env).
 
        * ``db_type`` must be ``Oracle``.
 
-       * ``db_name`` must be the same as Oracle SID.
+       * ``db_name`` and related parameters may be chosen with one of
+         following three methods:
+
+          * Specifying instance with system identifier (SID):
+
+            ``db_name`` specifies SID.
+            ``db_host`` must be set
+            (if ``db_port`` is not set, `1521` is used as port).
+
+            Example:
+            ``` code
+            db_name ORCL
+            db_host localhost
+            ```
+
+          * Specifying instance(s) with local naming:
+
+            ----
+            Note:
+
+              * Local naming is available on Sympa 6.2.37b.2 or later.
+
+            ----
+
+            ``db_name`` specifies net service name.
+            ``db_host`` must be `none` or must not be set.
+
+            Example:
+            ``` code
+            db_name net_service_name
+            ```
+
+            `tnsnames.ora` file on Sympa server has to include an entry for
+            specified net service name.
+            `tnsnames.ora` file is usually placed in the directory
+            `$ORACLE_HOME/network/admin`
+            (If you want to use this file in another place, specify the
+            directory by adding `TNS_ADMIN` environment variable to `db_env`
+            parameter described in below).
+
+          * Specifying connection with easy connection identifier:
+
+            ----
+            Note:
+
+              * Use of connection identifier is available on
+                Sympa 6.2.37b.2 or later.
+
+            ----
+
+            ``db_name`` specifies easy connection identifier.
+            ``db_host`` must be `none` or must not be set.
+
+            Examples:
+            ``` code
+            db_name db.example.org/service_name
+            ```
+            ``` code
+            db_name db.example.org:1521/name.dom.ain
+            ```
 
        * ``db_env`` should include definition of NLS_LANG and ORACLE_HOME.
          Character set should be `AL32UTF8`.
 
-       Example:
-       ``` code
-       db_type Oracle
-       db_name ORCL
-       db_host localhost
-       db_user sympa
-       db_passwd (secret)
-       db_env NLS_LANG=American_America.AL32UTF8;ORACLE_HOME=/u01/app/oracle/product/11.2.0/dbhome_1
-       ```
+     Example:
+     ``` code
+     db_type Oracle
+     db_name ORCL
+     db_host localhost
+     db_user sympa
+     db_passwd (secret)
+     db_env NLS_LANG=American_America.AL32UTF8;ORACLE_HOME=/u01/app/oracle/product/11.2.0/dbhome_1
+     ```
 
   2. Create database user:
      ```

--- a/manual/upgrade/notes.md
+++ b/manual/upgrade/notes.md
@@ -27,6 +27,23 @@ Following subsections describe changes by particular versions of 6.2.x.
 If you are planning to upgrade from version prior to 6.2, see also sections
 below.
 
+### From versions prior to 6.2.38
+
+  * If you have used Oracle Database, review
+    [`db_*`](../man/sympa.conf.5.md#database-related) parameters in
+    [`sympa.conf`](../layout.md#config):
+
+      - If you want to continue using SID (only method supported before) and
+        you have not set `db_host` parameter explicitly, add a line
+        ``` code
+        db_host localhost
+        ```
+        to `sympa.conf`.
+      - Or, you may choose the other methods.
+
+    For details see
+    [the instruction](../install/setup-database-oracle.md#general-instruction).
+
 ### From versions prior to 6.2.34
 
   * [`host`](../man/list_config.5.md#host) list parameter was deprecated. If you have used this parameter:


### PR DESCRIPTION
Update documentation according to enhancements with sympa-community/sympa#431: Oracle: Make db_name parameter allow net service name or connection identifier along with SID.

