### PR TITLE
nginx: `fastcgi_split_path_info` and so on are no longer required

### DIFF
--- a/manual/install/configure-http-server-spawnfcgi.md
+++ b/manual/install/configure-http-server-spawnfcgi.md
@@ -198,8 +198,7 @@ instruction below.
 #### nginx
 
   1. Add following excerpt to nginx configuration (Note:
-     replace [``$PIDDIR``](../layout.md#piddir),
-     [``$EXECCGIDIR``](../layout.md#execcgidir) and
+     replace [``$PIDDIR``](../layout.md#piddir) and
      [``$STATICDIR``](../layout.md#staticdir) below):
      ``` code
      server {
@@ -217,7 +216,8 @@ instruction below.
      }
      ```
 
-     For the SOAP interface, add this in your ``server`` configuration:
+     For the SOAP interface, add this in your ``server`` configuration (Note:
+     replace [``$PIDDIR``](../layout.md#piddir)):
      ```code
          location /sympasoap {
              include       /etc/nginx/fastcgi_params;
@@ -248,8 +248,9 @@ instruction below.
              fastcgi_param PATH_INFO $fastcgi_path_info;
              ```
 
-           - Additionally, with Sympa 6.2.19b.2 or earlier, insert these
-             into the section of "`location /sympa`":
+           - Additionally, with Sympa 6.2.19b.2 or earlier, insert this
+             into the section of "`location /sympa`" (Note:
+             replace [``$EXECCGIDIR``](../layout.md#execcgidir)).
              ``` code
              fastcgi_param SCRIPT_FILENAME $EXECCGIDIR/wwsympa.fcgi;
              ```

--- a/manual/install/configure-http-server-spawnfcgi.md
+++ b/manual/install/configure-http-server-spawnfcgi.md
@@ -209,11 +209,6 @@ instruction below.
          location /sympa {
              include       /etc/nginx/fastcgi_params;
              fastcgi_pass  unix:$PIDDIR/wwsympa.socket;
-
-             # If you changed wwsympa_url in sympa.conf, change this regex too!
-             fastcgi_split_path_info ^(/sympa)(.*)$;
-             fastcgi_param SCRIPT_FILENAME $EXECCGIDIR/wwsympa.fcgi;
-             fastcgi_param PATH_INFO $fastcgi_path_info;
          }
 
          location /static-sympa {
@@ -227,20 +222,37 @@ instruction below.
          location /sympasoap {
              include       /etc/nginx/fastcgi_params;
              fastcgi_pass  unix:$PIDDIR/sympasoap.socket;
-
-             fastcgi_param SCRIPT_FILENAME $EXECCGIDIR/sympa_soap_server.fcgi;
-             fastcgi_param PATH_INFO $fastcgi_path_info;
          }
      ```
+     See also a note below.
 
      ----
-     Note:
+     Notes:
 
        * Some binary distributions ship configuration ready to edit:
 
            - On RPM, ``/etc/nginx/conf.d/sympa.conf`` file is prepared by
              ``sympa-nginx`` package.
 
+       * With earlier version of Sympa, you may have to add following things:
+
+           - With Sympa 6.2.54 or earlier, insert these into the section of
+             "`location /sympa`":
+             ``` code
+             fastcgi_split_path_info ^(/sympa)(.*)$;
+             fastcgi_param PATH_INFO $fastcgi_path_info;
+             ```
+             and these into the section of "`location /sympasoap`", if any:
+             ``` code
+             fastcgi_split_path_info ^(/sympasoap)(.*)$;
+             fastcgi_param PATH_INFO $fastcgi_path_info;
+             ```
+
+           - Additionally, with Sympa 6.2.19b.2 or earlier, insert these
+             into the section of "`location /sympa`":
+             ``` code
+             fastcgi_param SCRIPT_FILENAME $EXECCGIDIR/wwsympa.fcgi;
+             ```
      ----
 
   2. Edit it as you prefer.

--- a/manual/upgrade/notes.md
+++ b/manual/upgrade/notes.md
@@ -27,6 +27,24 @@ Following subsections describe changes by particular versions of 6.2.x.
 If you are planning to upgrade from version prior to 6.2, see also sections
 below.
 
+### From version prior to 6.2.56
+
+(Coming later)
+
+  * [`http_host`](/gpldoc/man/sympa.conf.5.md#http_host) parameter:
+    Path component of this parameter is no longer optional.
+
+    If you are using this parameter in `sympa.conf` or `robot.conf`, such as
+    ``` code
+    http_host www.example.org
+    ```
+    it should be modified as
+    ``` code
+    http_host www.example.org/sympa
+    ```
+    Additionally, if you have added the `http_host` line as of Sympa prior to
+    6.2.20, it may simply be removed.
+
 ### From version prior to 6.2.54
 
   * If you are using the family_signoff link (the URL link in message footer

--- a/manual/upgrade/notes.md
+++ b/manual/upgrade/notes.md
@@ -31,19 +31,29 @@ below.
 
 (Coming later)
 
-  * [`http_host`](/gpldoc/man/sympa.conf.5.md#http_host) parameter:
-    Path component of this parameter is no longer optional.
+  * If you have set [`http_host`](/gpldoc/man/sympa.conf.5.md#http_host)
+    parameter in `sympa.conf` or `robot.conf`, you may have to change it.
 
-    If you are using this parameter in `sympa.conf` or `robot.conf`, such as
-    ``` code
-    http_host www.example.org
-    ```
-    it should be modified as
-    ``` code
-    http_host www.example.org/sympa
-    ```
-    Additionally, if you have added the `http_host` line as of Sympa prior to
-    6.2.20, it may simply be removed.
+      - If the value of `http_host` is identical to the host part of
+        `wwsympa_url` parameter, remove it.  For example,
+        ``` code
+        wwsympa_url http://web .example.org/sympa
+        http_host   web.example.org
+        ```
+        should be changed to
+        ``` code
+        wwsympa_url http://web.example.org/sympa
+        ```
+      - Otherwise, `http_host` has to contain path component.  For example,
+        ``` code
+        wwsympa_url http://web.example.org/sympa
+        http_host   backend.example.org
+        ```
+        should be modified as
+        ``` code
+        wwsympa_url http://web.example.org/sympa
+        http_host   backend.example.org/sympa
+        ```
 
 ### From version prior to 6.2.54
 

--- a/manual/upgrade/notes.md
+++ b/manual/upgrade/notes.md
@@ -35,24 +35,26 @@ below.
     parameter in `sympa.conf` or `robot.conf`, you may have to change it.
 
       - If the value of `http_host` is identical to the host part of
-        `wwsympa_url` parameter, remove it.  For example,
+        `wwsympa_url` parameter, it may simply be removed.  For example,
         ``` code
-        wwsympa_url http://web .example.org/sympa
-        http_host   web.example.org
+        wwsympa_url       http://web .example.org/sympa
+        http_host         web.example.org
         ```
-        should be changed to
+        may be changed to
         ``` code
-        wwsympa_url http://web.example.org/sympa
+        wwsympa_url       http://web.example.org/sympa
         ```
-      - Otherwise, `http_host` has to contain path component.  For example,
+      - Otherwise, you have to replace it with appropriate
+        [`wwsympa_url_local`](/gpldoc/man/sympa.conf.5.md#wwsympa_url_local)
+        parameter.  For example,
         ``` code
-        wwsympa_url http://web.example.org/sympa
-        http_host   backend.example.org
+        wwsympa_url       http://web.example.org/sympa
+        http_host         backend.example.org
         ```
         should be modified as
         ``` code
-        wwsympa_url http://web.example.org/sympa
-        http_host   backend.example.org/sympa
+        wwsympa_url       http://web.example.org/sympa
+        wwsympa_url_local http://backend.example.org/sympa
         ```
 
 ### From version prior to 6.2.54


### PR DESCRIPTION
  - As of 6.2.55b, Sympa will be able to split request URI into SCRIPT_NAME and PATH_INFO by Sympa itself. Thus documentation have to be tweaked.
    This change is related to sympa-community/sympa#879 .

  - As of 6.2.20, SCRIPT_FILENAME will no longer be required to check changes of wwsympa executable file.
