### PR TITLE
Update CAS page: Replace dead link and fix typo

### DIFF
--- a/manual/customize/cas.md
+++ b/manual/customize/cas.md
@@ -8,8 +8,8 @@ CAS single sign-on
 
 See also "[Authentication on web interface](authentication-web.md)".
 
-[CAS](https://developers.yale.edu/documentation/Administrative/cas) is the
-Yale University SSO software. Sympa's web interface (WWSympa) provides
+[CAS](https://github.com/apereo/cas) is the Apero CAS SSO software
+(originally developed by the Yale University). Sympa's web interface (WWSympa) provides
 [authentication mechanism](authentication-web.md#authentication-mechanisms)
 to use the CAS authentication service.
 

--- a/manual/customize/cas.md
+++ b/manual/customize/cas.md
@@ -49,7 +49,7 @@ cas
 
 Note:
 
-  - `base_url` specifys base URL of CAS server.
+  - `base_url` specifies base URL of CAS server.
 
   - If the `non_blocking_redirection` parameter was set for a CAS server, then
     WWSympa will try a transparent login on this server when the user accesses


### PR DESCRIPTION
The YALE university no longer provides the CAS software and the link we are using is dead now (see https://en.wikipedia.org/wiki/Jasig). 

Also fixes a typo on the same page.