### PR TITLE
Prevent unnecessary writes to disk

### DIFF
--- a/manual/install/configure-system-log.md
+++ b/manual/install/configure-system-log.md
@@ -36,7 +36,7 @@ Instruction by syslog servers
 
   2. Add following line to syslog.conf:
      ```
-     local1.* /var/log/sympa.log
+     local1.* -/var/log/sympa.log
      ```
 
   3. Reload syslog service.


### PR DESCRIPTION
The dash signifies that not every log entry is written immediately to the disk. This should be reserved to really important log messages like the auth log.
Most entries in a standard Syslog configuration indeed uses the dash.