### PR TITLE
Postfix: Add null_sender option to pipe(8) transports

### DIFF
--- a/manual/customize/automatic-lists.md
+++ b/manual/customize/automatic-lists.md
@@ -55,11 +55,11 @@ local_recipient_maps = pcre:/etc/postfix/local_recipient_regexp unix:passwd.byna
 /etc/postfix/master.cf (Note: Replace [``$LIBEXECDIR``](../layout.md#libexecdir) below)
 ``` code
 sympa     unix  -       n       n       -       -       pipe
-  flags=R user=sympa argv=$LIBEXECDIR/queue ${recipient}
+  flags=R null_sender= user=sympa argv=$LIBEXECDIR/queue ${recipient}
 sympabounce  unix  -       n       n       -       -       pipe
-  flags=R user=sympa argv=$LIBEXECDIR/bouncequeue ${user}
+  flags=R null_sender= user=sympa argv=$LIBEXECDIR/bouncequeue ${user}
 sympafamily  unix  -       n       n       -       -       pipe
-  flags=R user=sympa argv=$LIBEXECDIR/familyqueue ${user} age-occupation
+  flags=R null_sender= user=sympa argv=$LIBEXECDIR/familyqueue ${user} age-occupation
 ```
 
 A mail sent to `auto-cto.50@lists.domain.com` will be queued to the [``$SPOOLDIR``](../layout.md#spooldir)`/automatic` spool, defined by the `queueautomatic` `sympa.conf` parameter (see [`queueautomatic`](/gpldoc/man/sympa_config.5.html#queueautomatic)). The mail will first be processed by an instance of the `sympa.pl` process dedicated to automatic list creation, then the mail will be sent to the newly created mailing list.

--- a/manual/customize/automatic-lists.md
+++ b/manual/customize/automatic-lists.md
@@ -55,11 +55,11 @@ local_recipient_maps = pcre:/etc/postfix/local_recipient_regexp unix:passwd.byna
 /etc/postfix/master.cf (Note: Replace [``$LIBEXECDIR``](../layout.md#libexecdir) below)
 ``` code
 sympa     unix  -       n       n       -       -       pipe
-  flags=R null_sender= user=sympa argv=$LIBEXECDIR/queue ${recipient}
+  flags=hqRu null_sender= user=sympa argv=$LIBEXECDIR/queue ${recipient}
 sympabounce  unix  -       n       n       -       -       pipe
-  flags=R null_sender= user=sympa argv=$LIBEXECDIR/bouncequeue ${user}
+  flags=hqRu null_sender= user=sympa argv=$LIBEXECDIR/bouncequeue ${user}
 sympafamily  unix  -       n       n       -       -       pipe
-  flags=R null_sender= user=sympa argv=$LIBEXECDIR/familyqueue ${user} age-occupation
+  flags=hqRu null_sender= user=sympa argv=$LIBEXECDIR/familyqueue ${user} age-occupation
 ```
 
 A mail sent to `auto-cto.50@lists.domain.com` will be queued to the [``$SPOOLDIR``](../layout.md#spooldir)`/automatic` spool, defined by the `queueautomatic` `sympa.conf` parameter (see [`queueautomatic`](/gpldoc/man/sympa_config.5.html#queueautomatic)). The mail will first be processed by an instance of the `sympa.pl` process dedicated to automatic list creation, then the mail will be sent to the newly created mailing list.

--- a/manual/install/configure-mail-server-postfix.md
+++ b/manual/install/configure-mail-server-postfix.md
@@ -92,9 +92,9 @@ Steps in this section may be done once at the first time.
      replace [``$LIBEXECDIR``](../layout.md#libexecdir) below):
      ``` code
      sympa   unix    -       n       n       -       -       pipe
-       flags=hqRu user=sympa argv=$LIBEXECDIR/queue ${nexthop}
+       flags=hqRu null_sender= user=sympa argv=$LIBEXECDIR/queue ${nexthop}
      sympabounce unix -      n       n       -       -       pipe
-       flags=hqRu user=sympa argv=$LIBEXECDIR/bouncequeue ${nexthop}
+       flags=hqRu null_sender= user=sympa argv=$LIBEXECDIR/bouncequeue ${nexthop}
      ```
      Note that ``flags`` option have to contain ``R``. ``F`` is unnecessary.
 

--- a/manual/install/configure-mail-server-postfix.md
+++ b/manual/install/configure-mail-server-postfix.md
@@ -96,7 +96,11 @@ Steps in this section may be done once at the first time.
      sympabounce unix -      n       n       -       -       pipe
        flags=hqRu null_sender= user=sympa argv=$LIBEXECDIR/bouncequeue ${nexthop}
      ```
-     Note that ``flags`` option have to contain ``R``. ``F`` is unnecessary.
+     A few notes:
+
+      * ``flags`` attribute has to contain ``R``. ``F`` is unnecessary.
+      * ``null_sender`` attribute with empty value is required for
+        Postfix 2.3 or later.
 
   5. Edit Postfix ``main.cf`` file to add configuration for virtual domains
      (Note: replace [``$SYSCONFDIR``](../layout.md#sysconfdir) below):


### PR DESCRIPTION
sympa-community/sympa#1018: As of Postfix 2.3, Content of `Return-Path:` pseudo-header field added by pipe(8) for null envelope sender became "MAILER-DAEMON".  Empty `null_sender` option will prevent this behavior.
