### PR TITLE
Update documentation for Debian packages

### DIFF
--- a/manual/install/install-sympa-distribution-debian.md
+++ b/manual/install/install-sympa-distribution-debian.md
@@ -8,9 +8,10 @@ next: generate-initial-configuration.md
 Install Sympa distribution: Debian / Ubuntu
 ===========================================
 
-Binary packages of Sympa are prepared for Debian, Ubuntu or their derivatives.
+Binary packages of Sympa are prepared for Debian, Ubuntu and other derivatives.
+
 To install Sympa and dependent packages:
 
 ```bash
-$ apt-get --no-install-recommends install sympa doc-base locales logrotate
+$ apt install sympa
 ```


### PR DESCRIPTION
- Remove packages which are dependencies (for a long time)
- Decision about installing recommendations is up to the user
- Use shorthand and more fancy "apt" instead of "apt-get"
- Text update