### PR TITLE
exim4 configuration instruction

### DIFF
--- a/manual/install/configure-mail-server-exim4.md
+++ b/manual/install/configure-mail-server-exim4.md
@@ -79,7 +79,7 @@ Exim4 configuration
   you have to create a new router file under `router` directory, for instance
   ``/etc/exim4/conf.d/router/401_exim4-config_sympa_aliases``, and a new
   transport file under `transport` directory like
-  ``/etc/exim4/conf.d/router/401_exim4-config_sympa_aliases``
+  ``/etc/exim4/conf.d/transport/401_exim4-config_sympa_transport``
 
 ### Router part
 

--- a/manual/install/configure-mail-server-exim4.md
+++ b/manual/install/configure-mail-server-exim4.md
@@ -1,0 +1,131 @@
+---
+title: 'Configure mail server: Exim4'
+prev: configure-system-log.md
+up: configure-mail-server.md
+next: configure-mail-server.md#tests
+---
+
+Configure mail server: Exim4
+============================
+
+Requirements
+------------
+
+  * [Exim4](https://www.exim.org/).
+
+  * A mail domain name for the mailing list service.
+    See also "[Requirements](../requirements.md#network-requirements)".
+
+    In the instructions below, ``mail.example.org`` will be used for example.$
+
+  * [``$SYSCONFDIR``](../layout.md#sysconfdir) is the samba configuration
+    directory.
+    [``$SENDMAIL_ALIASES``](../layout.md#sendmail_aliases) designated
+    file alias.
+    [``$LIBEXECDIR``](../layout.md#libexecdir) is the execution directory.
+    You have to replace these symboles by their real value.
+
+Virtual domain setting
+----------------------
+### Initial setting
+
+Steps in this section may be done once at the first time.
+
+  1. If path of ``sendmail`` executable file is differ from the default value
+     of [``sendmail``](/gpldoc/man/sympa_config.5.html#sendmail) parameter,
+     ``/usr/sbin/sendmail``, define it in
+     [``sympa.conf``](../layout.md#config).  For example:
+
+     ``` code
+     sendmail /usr/local/sbin/sendmail
+     ```
+
+  2. Add the following to `sympa` configuration file [``sympa.conf``](../layout.md#config)
+
+     ``` code
+     sendmail_aliases $SENDMAIL_ALIASES.db
+     aliases_program newaliases
+     aliases_db_type hash
+     ```
+
+  3. It is seem that the alias file is created with .db extension. Do a link to
+     the original [``$SENDMAIL_ALIASES``](../layout.md#sendmail_aliases) to
+     ensure aliases is understood by both program
+
+     ``` code
+     ln -s "$SENDMAIL_ALIASES" "$SENDMAIL_ALIASES".db
+     ```
+
+  4. Create the `list_aliases.tt2` template file in [``$SYSCONFDIR``](../layout.md#sysconfdir)
+     directory with following content:
+     ``` code
+     #--- [% list.name %]@[% list.domain %]: list map created at [% date %]
+     [% list.name %]@[% list.domain %]: "| $LIBEXECDIR/queue [% list.name %]@[% list.domain %]"
+     [% list.name %]-request@[% list.domain %]: "| $LIBEXECDIR/queue [% list.name %]-request@[% list.domain %]"
+     [% list.name %]-editor@[% list.domain %]: "| $LIBEXECDIR/queue [% list.name %]-editor@[% list.domain %]"
+     [% list.name %]-subscribe@[% list.domain %]: "|  $LIBEXECDIR/queue [% list.name %]-subscribe@[%list.domain %]"
+     [% list.name %]-unsubscribe@[% list.domain %]: "|  $LIBEXECDIR/queue [% list.name %]-unsubscribe@[% list.domain %]"
+     [% list.name %][% return_path_suffix %]@[% list.domain %]: "|  $LIBEXECDIR/bouncequeue [% list.name %]@[% list.domain %]"
+     ```
+
+Exim4 configuration
+-------------------
+
+`Exim4` configuration steps
+
+  1. `Exim4` may work with a single monolithic configuration template file or
+     with several spited files according to your installation choice. If you
+     choose single monolithic way, you have to edit the
+     ``/etc/exim4/exim4.conf.template`` and put the following configuration
+     after the `system_aliases` section.
+
+     However, if you chose to split exim4
+     configuration template in several file, you have to create a new file in
+     router directory, named for instance:
+     ``/etc/exim4/conf.d/router/401_exim4-config_sympa_aliases``.
+     In doubt, you can make the both way.
+
+  2. So add the following section to the `exim4` configuration
+
+     ``` code
+     sympa_aliases:
+       debug_print = "R: sympa_aliases for $local_part@$domain"
+       driver = redirect
+       allow_fail
+       allow_defer
+       data = ${lookup{$local_part@$domain}lsearch{$SENDMAIL_ALIASES.db}}
+       user = sympa
+       group = sympa
+       file_transport = address_file
+       pipe_transport = address_pipe
+     ```
+
+  3. Run update-exim4 program to regenerate configuration
+
+     ``` code
+     update-exim4.conf
+     ```
+
+  4. Add `sympa` in system aliases, in /etc/aliases
+
+     ``` code
+     sympa: "| $LIBEXECDIR/queue sympa"
+     sympa-request: "| $LIBEXECDIR/queue sympa"
+     sympa-owner: "| $LIBEXECDIR/queue sympa"
+     sympa-listmaster: postmaster
+
+     postmaster: postmaster@mail.example.org
+     ```
+
+  5. Restart `sympa` and `exim4` service
+
+     ``` code
+     /etc/init.d/sympa restart
+     /etc/init.d/exim4 restart
+     ```
+
+  6. Test the routing plan
+
+     ``` code
+     exim4 -bt mail.example.org
+     ```

--- a/manual/install/configure-mail-server-exim4.md
+++ b/manual/install/configure-mail-server-exim4.md
@@ -128,7 +128,7 @@ Exim4 configuration
        group = sympa
        file_transport = address_file
        pipe_transport = address_pipe
-	   no_more
+       no_more
      ```
 
 ### Transport part
@@ -146,7 +146,7 @@ Exim4 configuration
     user = sympa
     group = sympa
     return_fail_output
-	return_path_add
+    return_path_add
 
   # Sympa transport for bouncequeue program
   sympa_bounce_queue_transport:
@@ -155,7 +155,7 @@ Exim4 configuration
     user = sympa
     group = sympa
     return_fail_output
-	return_path_add
+    return_path_add
   ```
 
 ### System steps
@@ -177,4 +177,4 @@ Exim4 configuration
 
      ``` code
      exim4 -bt list@mail.example.org
-     ```
+     `

--- a/manual/install/configure-mail-server-exim4.md
+++ b/manual/install/configure-mail-server-exim4.md
@@ -18,7 +18,7 @@ Requirements
 
     In the instructions below, ``mail.example.org`` will be used for example.
 
-  * [``$SYSCONFDIR``](../layout.md#sysconfdir) is the samba configuration
+  * [``$SYSCONFDIR``](../layout.md#sysconfdir) is the Sympa configuration
     directory.
     [``$SENDMAIL_ALIASES``](../layout.md#sendmail_aliases) designated
     file alias.
@@ -40,23 +40,14 @@ Steps in this section may be done once at the first time.
      sendmail /usr/local/sbin/sendmail
      ```
 
-  2. Add the following to `sympa` configuration file [``sympa.conf``](../layout.md#config)
+  2. Add the following to `Sympa` configuration file [``sympa.conf``](../layout.md#config)
 
      ``` code
-     sendmail_aliases $SENDMAIL_ALIASES.db
-     # aliases_program newaliases
-     # aliases_db_type hash
+     sendmail_aliases $SENDMAIL_ALIASES
+     aliases_program none
      ```
 
-  3. It is seem that the alias file is created with .db extension. Do a link to
-     the original [``$SENDMAIL_ALIASES``](../layout.md#sendmail_aliases) to
-     ensure aliases is understood by both program
-
-     ``` code
-     ln -s "$SENDMAIL_ALIASES" "$SENDMAIL_ALIASES".db
-     ```
-
-  4. Create the `list_aliases.tt2` template file in [``$SYSCONFDIR``](../layout.md#sysconfdir)
+  3. Create the `list_aliases.tt2` template file in [``$SYSCONFDIR``](../layout.md#sysconfdir)
      directory with following content:
 
      ``` code
@@ -131,13 +122,13 @@ Exim4 configuration
        driver = redirect
        allow_fail
        allow_defer
-       require_files = "{$SENDMAIL_ALIASES.db}"
-       data = ${lookup{$local_part@$domain}lsearch{$SENDMAIL_ALIASES.db}}
+       require_files = "+$SENDMAIL_ALIASES"
+       data = ${lookup{$local_part@$domain}lsearch{$SENDMAIL_ALIASES}}
        user = sympa
        group = sympa
        file_transport = address_file
        pipe_transport = address_pipe
-       return_path_add
+	   no_more
      ```
 
 ### Transport part
@@ -155,6 +146,7 @@ Exim4 configuration
     user = sympa
     group = sympa
     return_fail_output
+	return_path_add
 
   # Sympa transport for bouncequeue program
   sympa_bounce_queue_transport:
@@ -163,6 +155,7 @@ Exim4 configuration
     user = sympa
     group = sympa
     return_fail_output
+	return_path_add
   ```
 
 ### System steps
@@ -183,5 +176,5 @@ Exim4 configuration
   3. Test the routing plan
 
      ``` code
-     exim4 -bt mail.example.org
+     exim4 -bt list@mail.example.org
      ```

--- a/manual/install/configure-mail-server-exim4.md
+++ b/manual/install/configure-mail-server-exim4.md
@@ -106,7 +106,7 @@ Exim4 configuration
      update-exim4.conf
      ```
 
-  4. Add `sympa` in system aliases, in /etc/aliases
+ 4. Add `sympa` in system aliases, in /etc/aliases or in  [``$SENDMAIL_ALIASES``](../layout.md#sendmail_aliases)
 
      ``` code
      sympa: "| $LIBEXECDIR/queue sympa"
@@ -116,16 +116,26 @@ Exim4 configuration
 
      postmaster: postmaster@mail.example.org
      ```
+     
+  5. Update `/etc/exim4/exim4.conf.localmacros` to grant pipe transport
+     
+     ```code```
+     SYSTEM_ALIASES_PIPE_TRANSPORT = address_pipe
+     SYSTEM_ALIASES_FILE_TRANSPORT = address_file
+     ```
+     
+     This step is unnecessary if you decide to put the `sympa` alias definition in [``$SENDMAIL_ALIASES``](../layout.md#sendmail_aliases)
 
-  5. Restart `sympa` and `exim4` service
+  6. Restart `sympa` and `exim4` service
 
      ``` code
      /etc/init.d/sympa restart
      /etc/init.d/exim4 restart
      ```
 
-  6. Test the routing plan
+  7. Test the routing plan
 
      ``` code
      exim4 -bt mail.example.org
      ```
+ 


### PR DESCRIPTION
Creating missing _exim4_ documentation. File contains instruction to set up the _exim4_ mail server to work with _sympa_ command aliases and with the auto-generated list aliases.
This was tested on Debian 11 with single domain configuration.