### PR TITLE
Update configure-mail-server-exim4.md

### DIFF
--- a/manual/install/configure-mail-server-exim4.md
+++ b/manual/install/configure-mail-server-exim4.md
@@ -142,7 +142,7 @@ Exim4 configuration
   # Sympa transport for queue program
   sympa_queue_transport:
     driver = pipe
-    command = /usr/lib/sympa/bin/queue ${local_part}\@$domain
+    command = /usr/lib/sympa/bin/queue ${local_part_data}@${domain_data}
     user = sympa
     group = sympa
     return_fail_output
@@ -151,7 +151,7 @@ Exim4 configuration
   # Sympa transport for bouncequeue program
   sympa_bounce_queue_transport:
     driver = pipe
-    command = /usr/lib/sympa/bin/bouncequeue ${local_part}\@$domain
+    command = /usr/lib/sympa/bin/bouncequeue ${local_part_data}@${domain_data}
     user = sympa
     group = sympa
     return_fail_output


### PR DESCRIPTION
Exim>=4.94 transport doens’t allow taintend parameters in commands (3 years ago), so if you use current  SYMPA configuration for exim4 you would have this error 

"sympa-request@xxxx R=sympa_queue_aliases T=sympa_queue_transport: Tainted arg 1 for sympa_queue_transport transport command: 'sympa-request@xxxxxxxx’  

Upgrade local_part and domain variables to local_part_data and domain_data.

More information

https://www.gentoo.org/support/news-items/2021-05-04-exim-transports-disallow-tainted.html